### PR TITLE
Logo was not displaying in Firefox

### DIFF
--- a/images/contribsys-logo.svg
+++ b/images/contribsys-logo.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 18.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 234 72" enable-background="new 0 0 234 72" xml:space="preserve">
+	 width="300" height="auto" viewBox="0 0 234 72" enable-background="new 0 0 234 72" xml:space="preserve">
 <g>
 	<circle fill="#F9CE4A" cx="31.4" cy="23.2" r="2.9"/>
 	<circle fill="#F9CE4A" cx="35.8" cy="27.4" r="3.4"/>


### PR DESCRIPTION
Setting an explicit width on the SVG that matched the computed style in other browsers created consistent behavior in Firefox.