### PR TITLE
Add a11y polish: skip link, main landmark, brand focus ring

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -804,6 +804,58 @@
   }
 }
 
+/* ============ FOCUS RING ============
+   Brand-aligned focus indicator. Applied to all focusable interactives via
+   :focus-visible so mouse clicks don't trigger it. */
+
+:where(a, button, input, textarea, select, [tabindex]):focus-visible {
+  outline: 2px solid var(--cool-mint-700);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+.btn-pill:focus-visible {
+  outline: 2px solid var(--cool-mint-800);
+  outline-offset: 3px;
+  border-radius: var(--radius-md);
+}
+
+.mint-band a:focus-visible,
+.mint-band button:focus-visible {
+  outline-color: var(--soft-apricot-300);
+}
+
+/* ============ SKIP LINK ============
+   Hidden offscreen until focused. First tab-stop on every page. */
+
+.skip-link {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background: var(--cool-mint-900);
+  color: var(--text-on-inverse);
+  font-family: var(--font-subheading);
+  font-weight: 600;
+  padding: var(--space-sm) var(--space-lg);
+  border-radius: 0 0 var(--radius-sm) 0;
+  transform: translateY(-110%);
+  transition: transform 150ms cubic-bezier(0.25, 1, 0.5, 1);
+  z-index: 100;
+}
+
+.skip-link:focus,
+.skip-link:focus-visible {
+  transform: translateY(0);
+  outline: 2px solid var(--soft-apricot-300);
+  outline-offset: 2px;
+  text-decoration: none;
+  color: var(--text-on-inverse);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skip-link { transition: none; }
+}
+
 /* ============ RESPONSIVE ============ */
 
 @media (max-width: 767.98px) {

--- a/faktory/index.html
+++ b/faktory/index.html
@@ -16,6 +16,8 @@
   </head>
   <body>
 
+    <a class="skip-link" href="#main">Skip to main content</a>
+
     <header class="site-header">
       <div class="container">
         <nav class="navbar navbar-expand-lg">
@@ -39,13 +41,15 @@
       </div>
     </header>
 
+    <main id="main">
+
     <section class="hero">
       <div class="mint__stripes mint__stripes--right" aria-hidden="true"></div>
       <div class="container">
         <div class="row align-items-center">
           <div class="col-lg-6 faktory-hero__intro">
             <img src="../images/faktory-logo.svg" class="faktory-hero__logo" alt="Faktory">
-            <h2 class="faktory-hero__tagline">High-performance job processing for the polyglot enterprise.</h2>
+            <h1 class="faktory-hero__tagline">High-performance job processing for the polyglot enterprise.</h1>
           </div>
           <div class="col-lg-6 faktory-hero__screenshot">
             <img src="../images/faktory-ui.png" class="faktory-hero__ui framed" alt="Faktory Web UI">
@@ -66,20 +70,20 @@
           </thead>
           <tbody>
             <tr><td class="key">Audience</td><td>Hobbyists, Startups</td><td>Companies with Budgets</td></tr>
-            <tr><td class="key">Scheduled Jobs</td><td><span class="icon-yes" aria-label="yes"></span></td><td><span class="icon-yes" aria-label="yes"></span></td></tr>
-            <tr><td class="key">Responsive Web UI</td><td><span class="icon-yes" aria-label="yes"></span></td><td><span class="icon-yes" aria-label="yes"></span></td></tr>
-            <tr><td class="key">Polyglot Workers</td><td><span class="icon-yes" aria-label="yes"></span></td><td><span class="icon-yes" aria-label="yes"></span></td></tr>
-            <tr><td class="key"><a href="https://github.com/contribsys/faktory/wiki/Job-Errors">Error Handling</a></td><td><span class="icon-yes" aria-label="yes"></span></td><td><span class="icon-yes" aria-label="yes"></span></td></tr>
-            <tr><td class="key"><a href="https://github.com/contribsys/faktory/wiki/Docker">Docker Integration</a></td><td><span class="icon-yes" aria-label="yes"></span></td><td><span class="icon-yes" aria-label="yes"></span></td></tr>
-            <tr><td class="key"><a href="https://github.com/contribsys/faktory/wiki/Ent-Cron">Cron Jobs</a></td><td><span class="icon-no" aria-label="no"></span></td><td><span class="icon-yes" aria-label="yes"></span></td></tr>
-            <tr><td class="key"><a href="https://github.com/contribsys/faktory/wiki/Ent-Unique-Jobs">Unique Jobs</a></td><td><span class="icon-no" aria-label="no"></span></td><td><span class="icon-yes" aria-label="yes"></span></td></tr>
-            <tr><td class="key"><a href="https://github.com/contribsys/faktory/wiki/Ent-Expiring-Jobs">Expiring Jobs</a></td><td><span class="icon-no" aria-label="no"></span></td><td><span class="icon-yes" aria-label="yes"></span></td></tr>
-            <tr><td class="key"><a href="https://github.com/contribsys/faktory/wiki/Ent-Redis-Gateway">Redis Gateway</a></td><td><span class="icon-no" aria-label="no"></span></td><td><span class="icon-yes" aria-label="yes"></span></td></tr>
-            <tr><td class="key"><a href="https://github.com/contribsys/faktory/wiki/Ent-Metrics">Statsd Metrics</a></td><td><span class="icon-no" aria-label="no"></span></td><td><span class="icon-yes" aria-label="yes"></span></td></tr>
-            <tr><td class="key"><a href="https://github.com/contribsys/faktory/wiki/Ent-Throttling">Queue Throttling</a></td><td><span class="icon-no" aria-label="no"></span></td><td><span class="icon-yes" aria-label="yes"></span></td></tr>
-            <tr><td class="key"><a href="https://github.com/contribsys/faktory/wiki/Ent-Batches">Batches / Workflows</a></td><td><span class="icon-no" aria-label="no"></span></td><td><span class="icon-yes" aria-label="yes"></span></td></tr>
-            <tr><td class="key"><a href="https://github.com/contribsys/faktory/wiki/Ent-Tracking">Job Status</a></td><td><span class="icon-no" aria-label="no"></span></td><td><span class="icon-yes" aria-label="yes"></span></td></tr>
-            <tr><td class="key"><a href="https://github.com/contribsys/faktory/wiki/Ent-Misc">White Labeling</a></td><td><span class="icon-no" aria-label="no"></span></td><td><span class="icon-yes" aria-label="yes"></span></td></tr>
+            <tr><td class="key">Scheduled Jobs</td><td><span class="icon-yes" aria-label="Yes"></span></td><td><span class="icon-yes" aria-label="Yes"></span></td></tr>
+            <tr><td class="key">Responsive Web UI</td><td><span class="icon-yes" aria-label="Yes"></span></td><td><span class="icon-yes" aria-label="Yes"></span></td></tr>
+            <tr><td class="key">Polyglot Workers</td><td><span class="icon-yes" aria-label="Yes"></span></td><td><span class="icon-yes" aria-label="Yes"></span></td></tr>
+            <tr><td class="key"><a href="https://github.com/contribsys/faktory/wiki/Job-Errors">Error Handling</a></td><td><span class="icon-yes" aria-label="Yes"></span></td><td><span class="icon-yes" aria-label="Yes"></span></td></tr>
+            <tr><td class="key"><a href="https://github.com/contribsys/faktory/wiki/Docker">Docker Integration</a></td><td><span class="icon-yes" aria-label="Yes"></span></td><td><span class="icon-yes" aria-label="Yes"></span></td></tr>
+            <tr><td class="key"><a href="https://github.com/contribsys/faktory/wiki/Ent-Cron">Cron Jobs</a></td><td><span class="icon-no" aria-label="No"></span></td><td><span class="icon-yes" aria-label="Yes"></span></td></tr>
+            <tr><td class="key"><a href="https://github.com/contribsys/faktory/wiki/Ent-Unique-Jobs">Unique Jobs</a></td><td><span class="icon-no" aria-label="No"></span></td><td><span class="icon-yes" aria-label="Yes"></span></td></tr>
+            <tr><td class="key"><a href="https://github.com/contribsys/faktory/wiki/Ent-Expiring-Jobs">Expiring Jobs</a></td><td><span class="icon-no" aria-label="No"></span></td><td><span class="icon-yes" aria-label="Yes"></span></td></tr>
+            <tr><td class="key"><a href="https://github.com/contribsys/faktory/wiki/Ent-Redis-Gateway">Redis Gateway</a></td><td><span class="icon-no" aria-label="No"></span></td><td><span class="icon-yes" aria-label="Yes"></span></td></tr>
+            <tr><td class="key"><a href="https://github.com/contribsys/faktory/wiki/Ent-Metrics">Statsd Metrics</a></td><td><span class="icon-no" aria-label="No"></span></td><td><span class="icon-yes" aria-label="Yes"></span></td></tr>
+            <tr><td class="key"><a href="https://github.com/contribsys/faktory/wiki/Ent-Throttling">Queue Throttling</a></td><td><span class="icon-no" aria-label="No"></span></td><td><span class="icon-yes" aria-label="Yes"></span></td></tr>
+            <tr><td class="key"><a href="https://github.com/contribsys/faktory/wiki/Ent-Batches">Batches / Workflows</a></td><td><span class="icon-no" aria-label="No"></span></td><td><span class="icon-yes" aria-label="Yes"></span></td></tr>
+            <tr><td class="key"><a href="https://github.com/contribsys/faktory/wiki/Ent-Tracking">Job Status</a></td><td><span class="icon-no" aria-label="No"></span></td><td><span class="icon-yes" aria-label="Yes"></span></td></tr>
+            <tr><td class="key"><a href="https://github.com/contribsys/faktory/wiki/Ent-Misc">White Labeling</a></td><td><span class="icon-no" aria-label="No"></span></td><td><span class="icon-yes" aria-label="Yes"></span></td></tr>
             <tr><td class="key">Dedicated Support</td><td>None</td><td>Email</td></tr>
             <tr><td class="key">License</td><td>AGPL</td><td>Commercial</td></tr>
             <tr><td class="key">Pricing</td><td>Free</td><td>Starting at $299/mo</td></tr>
@@ -126,6 +130,8 @@
         </article>
       </div>
     </section>
+
+    </main>
 
     <footer class="site-footer">
       <div class="container">

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Contributed Systems</title>
+    <title>Contributed Systems — background job systems for modern applications</title>
     <meta name="description" content="Contributed Systems provides open source and commercial background job systems for ruby, go, python, elixir and javascript business applications">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
@@ -15,6 +15,8 @@
     <link rel="stylesheet" href="css/components.css">
   </head>
   <body>
+
+    <a class="skip-link" href="#main">Skip to main content</a>
 
     <header class="site-header">
       <div class="container">
@@ -38,6 +40,8 @@
         </nav>
       </div>
     </header>
+
+    <main id="main">
 
     <section class="hero">
       <div class="orange__stripes orange__stripes--left" aria-hidden="true"></div>
@@ -125,6 +129,8 @@
         </figure>
       </div>
     </section>
+
+    </main>
 
     <footer class="site-footer">
       <div class="container">


### PR DESCRIPTION
Make the site usable with keyboard + screen reader, looks polished when tabbing, better page titles.

<img width="259" height="87" alt="Screenshot 2026-05-07 at 11 44 30 PM" src="https://github.com/user-attachments/assets/e88ae219-566c-4499-8c99-416e055aab57" />

There's a little linter noise here in the Yes->yes and No->no. The complaint is that Yes/No read as keywords or IDs not natural text.